### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-5/Backend/security/code-scanning/1](https://github.com/Digital-5/Backend/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions right after `name` (or after `on`) with:

- `contents: read`

This preserves current functionality (`actions/checkout` continues to work) while preventing unintended broader token access if repo/org defaults change.  
Only `.github/workflows/maven.yml` needs to be edited; no imports, methods, or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
